### PR TITLE
feat: add MAX_LINES input param

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,15 @@ Please note that only those public events that belong to the following list show
 
 You can find an example [here](https://github.com/jamesgeorge007/jamesgeorge007/blob/master/.github/workflows/update-readme.yml).
 
-### Custom commit message or custom maximum number of populated lines
+### Override defaults
 
-Specify a custom commit message with the `COMMIT_MSG` input param.
+Use the following `input params` to customize it for your use case:-
 
-Specify a custom maximum number of lines with the `MAX_LINES` input param *(default is 5)*.
+| Input Param | Default Value | Description |
+|--------|--------|--------|
+| `COMMIT_MSG` | :zap: Update README with the recent activity | Commit message used while committing to the repo |
+| `MAX_LINES` | 5 | The maximum number of lines populated in your readme file |
+
 
 ```yml
 name: Update README

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ Please note that only those public events that belong to the following list show
 
 You can find an example [here](https://github.com/jamesgeorge007/jamesgeorge007/blob/master/.github/workflows/update-readme.yml).
 
-### Custom commit message
+### Custom commit message or custom maximum number of populated lines
 
 Specify a custom commit message with the `COMMIT_MSG` input param.
+
+Specify a custom maximum number of lines with the `MAX_LINES` input param *(default is 5)*.
 
 ```yml
 name: Update README
@@ -68,6 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           COMMIT_MSG: 'Specify a custom commit message'
+          MAX_LINES: 10
 ```
 
 _Inspired by [JasonEtco/activity-box](https://github.com/JasonEtco/activity-box)_

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "Commit message used while committing to the repo"
     default: ":zap: Update README with the recent activity"
     required: false
+  MAX_LINES:
+    description: "The maximum number of lines populated in your readme file"
+    default: 5
+    required: false
 
 branding:
   color: yellow

--- a/dist/index.js
+++ b/dist/index.js
@@ -1479,11 +1479,10 @@ const path = __webpack_require__(622);
 const { spawn } = __webpack_require__(129);
 const { Toolkit } = __webpack_require__(461);
 
-const MAX_LINES = 5;
-
 // Get config
 const GH_USERNAME = core.getInput("GH_USERNAME");
 const COMMIT_MSG = core.getInput("COMMIT_MSG");
+const MAX_LINES = core.getInput("MAX_LINES");
 /**
  * Returns the sentence case representation
  * @param {String} str - the string

--- a/index.js
+++ b/index.js
@@ -4,11 +4,10 @@ const path = require("path");
 const { spawn } = require("child_process");
 const { Toolkit } = require("actions-toolkit");
 
-const MAX_LINES = 5;
-
 // Get config
 const GH_USERNAME = core.getInput("GH_USERNAME");
 const COMMIT_MSG = core.getInput("COMMIT_MSG");
+const MAX_LINES = core.getInput("MAX_LINES");
 /**
  * Returns the sentence case representation
  * @param {String} str - the string


### PR DESCRIPTION
Allowing you to set the maximum populated lines in your workflow, falls back to `5` if not defined.