### PR TITLE
Update Email Address for GitHub Actions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1547,7 +1547,7 @@ const commitFile = async () => {
     "config",
     "--global",
     "user.email",
-    "readme-bot@example.com",
+    "41898282+github-actions[bot]@users.noreply.github.com",
   ]);
   await exec("git", ["config", "--global", "user.name", "readme-bot"]);
   await exec("git", ["add", "README.md"]);

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ const commitFile = async () => {
     "config",
     "--global",
     "user.email",
-    "readme-bot@example.com",
+    "41898282+github-actions[bot]@users.noreply.github.com",
   ]);
   await exec("git", ["config", "--global", "user.name", "readme-bot"]);
   await exec("git", ["add", "README.md"]);


### PR DESCRIPTION
Since, we are using GitHub Actions anyways, it's better we use `41898282+github-actions[bot]@users.noreply.github.com` for commits, so that we can have GitHub Actions icon.