### PR TITLE
Add custom committer name and email

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,14 @@ Updates `README.md` with the recent GitHub activity of a user.
 
 ```yml
 name: Update README
-
 on:
   schedule:
     - cron: '*/30 * * * *'
   workflow_dispatch:
-
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Update this repo's README with recent activity
-
     steps:
       - uses: actions/checkout@v2
       - uses: jamesgeorge007/github-activity-readme@master
@@ -50,23 +47,22 @@ Use the following `input params` to customize it for your use case:-
 
 | Input Param | Default Value | Description |
 |--------|--------|--------|
+| `COMMIT_NAME` | readme-bot | Name of the committer |
+| `COMMIT_EMAIL` | 41898282+github-actions[bot]@users.noreply.github.com | Email of the committer |
 | `COMMIT_MSG` | :zap: Update README with the recent activity | Commit message used while committing to the repo |
 | `MAX_LINES` | 5 | The maximum number of lines populated in your readme file |
 
 
 ```yml
 name: Update README
-
 on:
   schedule:
     - cron: '*/30 * * * *'
   workflow_dispatch:
-
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Update this repo's README with recent activity
-
     steps:
       - uses: actions/checkout@v2
       - uses: jamesgeorge007/github-activity-readme@master
@@ -75,6 +71,7 @@ jobs:
         with:
           COMMIT_MSG: 'Specify a custom commit message'
           MAX_LINES: 10
+          COMMIT_NAME: GitHub Activity Readme
 ```
 
 _Inspired by [JasonEtco/activity-box](https://github.com/JasonEtco/activity-box)_

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,14 @@ inputs:
     description: "Commit message used while committing to the repo"
     default: ":zap: Update README with the recent activity"
     required: false
+  COMMIT_NAME: 
+    description: "Name of the committer"
+    default: "readme-bot"
+    required: false
+  COMMIT_EMAIL:
+    description: "Email of the committer"
+    default: "41898282+github-actions[bot]@users.noreply.github.com"
+    required: false
   MAX_LINES:
     description: "The maximum number of lines populated in your readme file"
     default: 5

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const toUrlFormat = (item) => {
   if (typeof item === "object") {
     return Object.hasOwnProperty.call(item.payload, "issue")
       ? `[#${item.payload.issue.number}](${urlPrefix}/${item.repo.name}/issues/${item.payload.issue.number})`
-      : `[#${item.payload.pull_request.number}](${urlPrefix}/${item.repo.name}/pull/${item.payload.pull_request.number})`;   
+      : `[#${item.payload.pull_request.number}](${urlPrefix}/${item.repo.name}/pull/${item.payload.pull_request.number})`;
   }
   return `[${item}](${urlPrefix}/${item})`;
 };

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const toUrlFormat = (item) => {
   if (typeof item === "object") {
     return Object.hasOwnProperty.call(item.payload, "issue")
       ? `[#${item.payload.issue.number}](${urlPrefix}/${item.repo.name}/issues/${item.payload.issue.number})`
-      : `[#${item.payload.pull_request.number}](${urlPrefix}/${item.repo.name}/pull/${item.payload.pull_request.number})`;
+      : `[#${item.payload.pull_request.number}](${urlPrefix}/${item.repo.name}/pull/${item.payload.pull_request.number})`;   
   }
   return `[${item}](${urlPrefix}/${item})`;
 };
@@ -70,12 +70,7 @@ const exec = (cmd, args = []) =>
  */
 
 const commitFile = async () => {
-  await exec("git", [
-    "config",
-    "--global",
-    "user.email",
-    COMMIT_EMAIL,
-  ]);
+  await exec("git", ["config", "--global", "user.email", COMMIT_EMAIL]);
   await exec("git", ["config", "--global", "user.name", COMMIT_NAME]);
   await exec("git", ["add", "README.md"]);
   await exec("git", ["commit", "-m", COMMIT_MSG]);

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const { Toolkit } = require("actions-toolkit");
 
 // Get config
 const GH_USERNAME = core.getInput("GH_USERNAME");
+const COMMIT_NAME = core.getInput("COMMIT_NAME");
+const COMMIT_EMAIL = core.getInput("COMMIT_EMAIL");
 const COMMIT_MSG = core.getInput("COMMIT_MSG");
 const MAX_LINES = core.getInput("MAX_LINES");
 /**
@@ -72,9 +74,9 @@ const commitFile = async () => {
     "config",
     "--global",
     "user.email",
-    "41898282+github-actions[bot]@users.noreply.github.com",
+    COMMIT_EMAIL,
   ]);
-  await exec("git", ["config", "--global", "user.name", "readme-bot"]);
+  await exec("git", ["config", "--global", "user.name", COMMIT_NAME]);
   await exec("git", ["add", "README.md"]);
   await exec("git", ["commit", "-m", COMMIT_MSG]);
   await exec("git", ["push"]);


### PR DESCRIPTION
Custom Committer
===

As already asked from another user in [#44](https://github.com/jamesgeorge007/github-activity-readme/issues/44) I created two variables to add committer email and name.


| Input Param | Default Value | Description |
|--------|--------|--------|
| `COMMIT_NAME` | readme-bot | Name of the committer |
| `COMMIT_EMAIL` | 41898282+github-actions[bot]@users.noreply.github.com | Email of the committer |