### PR TITLE
Feat: Adds option to specify the target file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Use the following `input params` to customize it for your use case:-
 |--------|--------|--------|
 | `COMMIT_MSG` | :zap: Update README with the recent activity | Commit message used while committing to the repo |
 | `MAX_LINES` | 5 | The maximum number of lines populated in your readme file |
-
+| `TARGET_FILE` | README.md | The file to insert recent activity into |
 
 ```yml
 name: Update README

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,10 @@ inputs:
     description: "The maximum number of lines populated in your readme file"
     default: 5
     required: false
-
+  TARGET_FILE:
+    description: "The file location to write changes to"
+    default: "README.md"
+    required: false
 branding:
   color: yellow
   icon: activity

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const { Toolkit } = require("actions-toolkit");
 const GH_USERNAME = core.getInput("GH_USERNAME");
 const COMMIT_MSG = core.getInput("COMMIT_MSG");
 const MAX_LINES = core.getInput("MAX_LINES");
+const TARGET_FILE = core.getInput("TARGET_FILE") || "README.md";
+
 /**
  * Returns the sentence case representation
  * @param {String} str - the string
@@ -75,7 +77,7 @@ const commitFile = async () => {
     "41898282+github-actions[bot]@users.noreply.github.com",
   ]);
   await exec("git", ["config", "--global", "user.name", "readme-bot"]);
-  await exec("git", ["add", "README.md"]);
+  await exec("git", ["add", TARGET_FILE]);
   await exec("git", ["commit", "-m", COMMIT_MSG]);
   await exec("git", ["push"]);
 };
@@ -120,7 +122,7 @@ Toolkit.run(
       // Call the serializer to construct a string
       .map((item) => serializers[item.type](item));
 
-    const readmeContent = fs.readFileSync("./README.md", "utf-8").split("\n");
+    const readmeContent = fs.readFileSync(`./${TARGET_FILE}`, "utf-8").split("\n");
 
     // Find the index corresponding to <!--START_SECTION:activity--> comment
     let startIdx = readmeContent.findIndex(
@@ -162,7 +164,7 @@ Toolkit.run(
       );
 
       // Update README
-      fs.writeFileSync("./README.md", readmeContent.join("\n"));
+      fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
 
       // Commit to the remote repository
       try {
@@ -194,7 +196,7 @@ Toolkit.run(
         }
         readmeContent.splice(startIdx + idx, 0, `${idx + 1}. ${line}`);
       });
-      tools.log.success("Wrote to README");
+      tools.log.success(`Wrote to ${TARGET_FILE}`);
     } else {
       // It is likely that a newline is inserted after the <!--START_SECTION:activity--> comment (code formatter)
       let count = 0;
@@ -209,11 +211,11 @@ Toolkit.run(
           count++;
         }
       });
-      tools.log.success("Updated README with the recent activity");
+      tools.log.success(`Updated ${TARGET_FILE} with the recent activity`);
     }
 
     // Update README
-    fs.writeFileSync("./README.md", readmeContent.join("\n"));
+    fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
 
     // Commit to the remote repository
     try {


### PR DESCRIPTION
Hi @jamesgeorge007 👋
Love your action, it's been very useful :) 

Re issue: #68

This PR implements the option to use a file other than the readme, by specifying a `TARGET_FILE`.
If  it isn't specified, it will continue to use `README.md`, so is fully backwards compatible.

Let me know if there's anything you'd like me to change,
Have a great day!
