### PR TITLE
changed `Node.js 12` to `Node.js 16`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - run: npm ci
       - run: npm run format:check
       - run: npm run build

--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ branding:
   icon: activity
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Context - https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/