### PR TITLE
Updated node.js from v12 to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ branding:
   icon: activity
 
 runs:
-  using: node16
+  using: node18
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ branding:
   icon: activity
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Node.js version 12 is being used, but GitHub recommends updating it to version 16.