### PR TITLE
fix: prevent stack trace on the course of error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1858,13 +1858,13 @@ const exec = (cmd, args = []) =>
 
     app.on("close", (code) => {
       if (code !== 0 && !stdout.includes("nothing to commit")) {
-        return reject({ code, message: stderr });
+        return reject({ code, stderr });
       }
 
-      return resolve({ code, stdout });
+      return resolve();
     });
 
-    app.on("error", () => reject({ code: 1, message: stderr }));
+    app.on("error", () => reject({ code: 1, stderr }));
   });
 
 /**
@@ -1992,7 +1992,8 @@ Toolkit.run(
       try {
         await commitFile();
       } catch (err) {
-        return tools.exit.failure(err.message);
+        const message = `Exit code: ${err.code}\n${err.stderr}`;
+        return tools.exit.failure(message);
       }
       tools.exit.success("Wrote to README");
     }
@@ -2042,7 +2043,8 @@ Toolkit.run(
     try {
       await commitFile();
     } catch (err) {
-      return tools.exit.failure(err.message);
+      const message = `Exit code: ${err.code}\n${err.stderr}`;
+      return tools.exit.failure(message);
     }
     tools.exit.success("Pushed to remote repository");
   },

--- a/index.js
+++ b/index.js
@@ -75,13 +75,13 @@ const exec = (cmd, args = []) =>
 
     app.on("close", (code) => {
       if (code !== 0 && !stdout.includes("nothing to commit")) {
-        return reject({ code, message: stderr });
+        return reject({ code, stderr });
       }
 
-      return resolve({ code, stdout });
+      return resolve();
     });
 
-    app.on("error", () => reject({ code: 1, message: stderr }));
+    app.on("error", () => reject({ code: 1, stderr }));
   });
 
 /**
@@ -209,7 +209,8 @@ Toolkit.run(
       try {
         await commitFile();
       } catch (err) {
-        return tools.exit.failure(err.message);
+        const message = `Exit code: ${err.code}\n${err.stderr}`;
+        return tools.exit.failure(message);
       }
       tools.exit.success("Wrote to README");
     }
@@ -259,7 +260,8 @@ Toolkit.run(
     try {
       await commitFile();
     } catch (err) {
-      return tools.exit.failure(err.message);
+      const message = `Exit code: ${err.code}\n${err.stderr}`;
+      return tools.exit.failure(message);
     }
     tools.exit.success("Pushed to remote repository");
   },

--- a/index.js
+++ b/index.js
@@ -57,20 +57,31 @@ const toUrlFormat = (item) => {
 
 const exec = (cmd, args = []) =>
   new Promise((resolve, reject) => {
-    const app = spawn(cmd, args, { stdio: "pipe" });
+    const app = spawn(cmd, args);
+
     let stdout = "";
-    app.stdout.on("data", (data) => {
-      stdout = data;
-    });
+    if (app.stdout) {
+      app.stdout.on("data", (data) => {
+        stdout += data.toString();
+      });
+    }
+
+    let stderr = "";
+    if (app.stderr) {
+      app.stderr.on("data", (data) => {
+        stderr += data.toString();
+      });
+    }
+
     app.on("close", (code) => {
       if (code !== 0 && !stdout.includes("nothing to commit")) {
-        err = new Error(`Invalid status code: ${code}`);
-        err.code = code;
-        return reject(err);
+        return reject({ code, message: stderr });
       }
-      return resolve(code);
+
+      return resolve({ code, stdout });
     });
-    app.on("error", reject);
+
+    app.on("error", () => reject({ code: 1, message: stderr }));
   });
 
 /**
@@ -198,8 +209,7 @@ Toolkit.run(
       try {
         await commitFile();
       } catch (err) {
-        tools.log.debug("Something went wrong");
-        return tools.exit.failure(err);
+        return tools.exit.failure(err.message);
       }
       tools.exit.success("Wrote to README");
     }
@@ -249,8 +259,7 @@ Toolkit.run(
     try {
       await commitFile();
     } catch (err) {
-      tools.log.debug("Something went wrong");
-      return tools.exit.failure(err);
+      return tools.exit.failure(err.message);
     }
     tools.exit.success("Pushed to remote repository");
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-activity-readme",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Updates README with the recent GitHub activity of a user",
   "main": "index.js",
   "keywords": [],


### PR DESCRIPTION
It is difficult to debug when the workflow fails since the internal stack trace is what gets logged currently. For instance, #112. This PR aims at fixing this behaviour by logging the content of the stderr stream instead.

## Before

![before](https://github.com/jamesgeorge007/github-activity-readme/assets/25279263/d38dc2c6-2e22-43f7-b019-ac5df1f9b357)

## After

![after](https://github.com/jamesgeorge007/github-activity-readme/assets/25279263/440f2361-9738-4853-a797-6a920adcc0e5)