### PR TITLE
feat: filtering of event types

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Use the following `input params` to customize it for your use case:-
 | `EMPTY_COMMIT_MSG` | :memo: empty commit to keep workflow active after 60 days of no activity | Commit message used when there are no updates             |
 | `MAX_LINES`        | 5                                                                        | The maximum number of lines populated in your readme file |
 | `TARGET_FILE`      | README.md                                                                | The file to insert recent activity into                   |
+| `FILTER_EVENTS`    | IssueCommentEvent, IssuesEvent, PullRequestEvent, ReleaseEvent           | Display specific event type                               |
 
 ```yml
 name: Update README

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Use the following `input params` to customize it for your use case:-
 | `EMPTY_COMMIT_MSG` | :memo: empty commit to keep workflow active after 60 days of no activity | Commit message used when there are no updates             |
 | `MAX_LINES`        | 5                                                                        | The maximum number of lines populated in your readme file |
 | `TARGET_FILE`      | README.md                                                                | The file to insert recent activity into                   |
-| `FILTER_EVENTS`    | IssueCommentEvent, IssuesEvent, PullRequestEvent, ReleaseEvent           | Display specific event type                               |
+| `FILTER_EVENTS`    | IssueCommentEvent,IssuesEvent,PullRequestEvent,ReleaseEvent              | Display specific event type                               |
 
 ```yml
 name: Update README

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,11 @@ inputs:
     description: "Commit message used when there are no updates"
     default: ":memo: empty commit to keep workflow active after 60 days of no activity"
     required: false
+  FILTER_EVENTS:
+    description: "Events that should be displayed on profile"
+    default: [ "IssueCommentEvent", "IssuesEvent", "PullRequestEvent", "ReleaseEvent" ]
+    required: false
+
 branding:
   color: yellow
   icon: activity

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
   FILTER_EVENTS:
     description: "Events that should be displayed on profile"
-    default: [ "IssueCommentEvent", "IssuesEvent", "PullRequestEvent", "ReleaseEvent" ]
+    default: '[ "IssueCommentEvent", "IssuesEvent", "PullRequestEvent", "ReleaseEvent" ]'
     required: false
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
   FILTER_EVENTS:
     description: "Events that should be displayed on profile"
-    default: "IssueCommentEvent, IssuesEvent, PullRequestEvent, ReleaseEvent"
+    default: "IssueCommentEvent,IssuesEvent,PullRequestEvent,ReleaseEvent"
     required: false
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -33,11 +33,7 @@ inputs:
     required: false
   FILTER_EVENTS:
     description: "Events that should be displayed on profile"
-    default: 
-      - "IssueCommentEvent"
-      - "IssuesEvent" 
-      - "PullRequestEvent" 
-      - "ReleaseEvent"
+    default: "IssueCommentEvent, IssuesEvent, PullRequestEvent, ReleaseEvent"
     required: false
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,11 @@ inputs:
     required: false
   FILTER_EVENTS:
     description: "Events that should be displayed on profile"
-    default: '[ "IssueCommentEvent", "IssuesEvent", "PullRequestEvent", "ReleaseEvent" ]'
+    default: 
+      - "IssueCommentEvent"
+      - "IssuesEvent" 
+      - "PullRequestEvent" 
+      - "ReleaseEvent"
     required: false
 
 branding:

--- a/dist/index.js
+++ b/dist/index.js
@@ -20065,8 +20065,6 @@ Toolkit.run(
       .slice(0, MAX_LINES)
       // Call the serializer to construct a string
       .map((item) => serializers[item.type](item));
-	
-	tools.log.debug(content)
 
     const readmeContent = fs
       .readFileSync(`./${TARGET_FILE}`, "utf-8")

--- a/dist/index.js
+++ b/dist/index.js
@@ -20060,7 +20060,11 @@ Toolkit.run(
 
     const content = events.data
       // Filter out any boring activity
-      .filter((event) => serializers.hasOwnProperty(event.type) && FILTER_EVENTS.includes(event.type))
+      .filter(
+        (event) =>
+          serializers.hasOwnProperty(event.type) &&
+          FILTER_EVENTS.includes(event.type),
+      )
       // We only have five lines to work with
       .slice(0, MAX_LINES)
       // Call the serializer to construct a string

--- a/dist/index.js
+++ b/dist/index.js
@@ -20048,16 +20048,14 @@ const serializers = {
 
 Toolkit.run(
   async (tools) => {
-	console.log("Print")
-	tools.log.debug("Filters:" + FILTER_EVENTS)
     // Get the user's public events
-    tools.log.debug(`Getting activity for ${GH_USERNAME} pls`);
+    tools.log.debug(`Getting activity for ${GH_USERNAME}`);
     const events = await tools.github.activity.listPublicEventsForUser({
       username: GH_USERNAME,
       per_page: 100,
     });
     tools.log.debug(
-      `Activity for ${GH_USERNAME}, ${events.data.length} events found YES.`,
+      `Activity for ${GH_USERNAME}, ${events.data.length} events found.`,
     );
 
     const content = events.data

--- a/dist/index.js
+++ b/dist/index.js
@@ -19862,15 +19862,14 @@ const { spawn } = __nccwpck_require__(5317);
 const { Toolkit } = __nccwpck_require__(2288);
 
 // Get config
-const GH_USERNAME = "DogeTheBeast"
+const GH_USERNAME = core.getInput("GH_USERNAME");
 const COMMIT_NAME = core.getInput("COMMIT_NAME");
 const COMMIT_EMAIL = core.getInput("COMMIT_EMAIL");
 const COMMIT_MSG = core.getInput("COMMIT_MSG");
-const MAX_LINES = 5
-const TARGET_FILE = "README.md"
+const MAX_LINES = core.getInput("MAX_LINES");
+const TARGET_FILE = core.getInput("TARGET_FILE");
 const EMPTY_COMMIT_MSG = core.getInput("EMPTY_COMMIT_MSG");
-// const FILTER_EVENTS = core.getInput("FILTER_EVENTS");
-const FILTER_EVENTS = '["IssueCommentEvent"]'
+const FILTER_EVENTS = core.getInput("FILTER_EVENTS");
 
 /**
  * Returns the sentence case representation
@@ -20122,14 +20121,14 @@ Toolkit.run(
       );
 
       // Update README
-      // fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
-      //
-      // // Commit to the remote repository
-      // try {
-      //   await commitFile();
-      // } catch (err) {
-      //   return tools.exit.failure(err.message);
-      // }
+      fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
+
+      // Commit to the remote repository
+      try {
+        await commitFile();
+      } catch (err) {
+        return tools.exit.failure(err.message);
+      }
       tools.exit.success("Wrote to README");
     }
 
@@ -20172,18 +20171,18 @@ Toolkit.run(
     }
 
     // Update README
-    // fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
-    //
-    // // Commit to the remote repository
-    // try {
-    //   await commitFile();
-    // } catch (err) {
-    //   return tools.exit.failure(err.message);
-    // }
+    fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
+
+    // Commit to the remote repository
+    try {
+      await commitFile();
+    } catch (err) {
+      return tools.exit.failure(err.message);
+    }
     tools.exit.success("Pushed to remote repository");
   },
   {
-    // event: ["schedule", "workflow_dispatch"],
+    event: ["schedule", "workflow_dispatch"],
     secrets: ["GITHUB_TOKEN"],
   },
 );

--- a/dist/index.js
+++ b/dist/index.js
@@ -19862,13 +19862,15 @@ const { spawn } = __nccwpck_require__(5317);
 const { Toolkit } = __nccwpck_require__(2288);
 
 // Get config
-const GH_USERNAME = core.getInput("GH_USERNAME");
+const GH_USERNAME = "DogeTheBeast"
 const COMMIT_NAME = core.getInput("COMMIT_NAME");
 const COMMIT_EMAIL = core.getInput("COMMIT_EMAIL");
 const COMMIT_MSG = core.getInput("COMMIT_MSG");
-const MAX_LINES = core.getInput("MAX_LINES");
-const TARGET_FILE = core.getInput("TARGET_FILE");
+const MAX_LINES = 5
+const TARGET_FILE = "README.md"
 const EMPTY_COMMIT_MSG = core.getInput("EMPTY_COMMIT_MSG");
+// const FILTER_EVENTS = core.getInput("FILTER_EVENTS");
+const FILTER_EVENTS = '["IssueCommentEvent"]'
 
 /**
  * Returns the sentence case representation
@@ -20047,23 +20049,27 @@ const serializers = {
 
 Toolkit.run(
   async (tools) => {
+	console.log("Print")
+	tools.log.debug("Filters:" + FILTER_EVENTS)
     // Get the user's public events
-    tools.log.debug(`Getting activity for ${GH_USERNAME}`);
+    tools.log.debug(`Getting activity for ${GH_USERNAME} pls`);
     const events = await tools.github.activity.listPublicEventsForUser({
       username: GH_USERNAME,
       per_page: 100,
     });
     tools.log.debug(
-      `Activity for ${GH_USERNAME}, ${events.data.length} events found.`,
+      `Activity for ${GH_USERNAME}, ${events.data.length} events found YES.`,
     );
 
     const content = events.data
       // Filter out any boring activity
-      .filter((event) => serializers.hasOwnProperty(event.type))
+      .filter((event) => serializers.hasOwnProperty(event.type) && FILTER_EVENTS.includes(event.type))
       // We only have five lines to work with
       .slice(0, MAX_LINES)
       // Call the serializer to construct a string
       .map((item) => serializers[item.type](item));
+	
+	tools.log.debug(content)
 
     const readmeContent = fs
       .readFileSync(`./${TARGET_FILE}`, "utf-8")
@@ -20116,14 +20122,14 @@ Toolkit.run(
       );
 
       // Update README
-      fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
-
-      // Commit to the remote repository
-      try {
-        await commitFile();
-      } catch (err) {
-        return tools.exit.failure(err.message);
-      }
+      // fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
+      //
+      // // Commit to the remote repository
+      // try {
+      //   await commitFile();
+      // } catch (err) {
+      //   return tools.exit.failure(err.message);
+      // }
       tools.exit.success("Wrote to README");
     }
 
@@ -20166,18 +20172,18 @@ Toolkit.run(
     }
 
     // Update README
-    fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
-
-    // Commit to the remote repository
-    try {
-      await commitFile();
-    } catch (err) {
-      return tools.exit.failure(err.message);
-    }
+    // fs.writeFileSync(`./${TARGET_FILE}`, readmeContent.join("\n"));
+    //
+    // // Commit to the remote repository
+    // try {
+    //   await commitFile();
+    // } catch (err) {
+    //   return tools.exit.failure(err.message);
+    // }
     tools.exit.success("Pushed to remote repository");
   },
   {
-    event: ["schedule", "workflow_dispatch"],
+    // event: ["schedule", "workflow_dispatch"],
     secrets: ["GITHUB_TOKEN"],
   },
 );

--- a/index.js
+++ b/index.js
@@ -190,6 +190,7 @@ const serializers = {
 
 Toolkit.run(
   async (tools) => {
+	console.log("Print")
 	tools.log.debug("Filters:" + FILTER_EVENTS)
     // Get the user's public events
     tools.log.debug(`Getting activity for ${GH_USERNAME}`);

--- a/index.js
+++ b/index.js
@@ -202,7 +202,11 @@ Toolkit.run(
 
     const content = events.data
       // Filter out any boring activity
-      .filter((event) => serializers.hasOwnProperty(event.type) && FILTER_EVENTS.includes(event.type))
+      .filter(
+        (event) =>
+          serializers.hasOwnProperty(event.type) &&
+          FILTER_EVENTS.includes(event.type),
+      )
       // We only have five lines to work with
       .slice(0, MAX_LINES)
       // Call the serializer to construct a string

--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ Toolkit.run(
 	console.log("Print")
 	tools.log.debug("Filters:" + FILTER_EVENTS)
     // Get the user's public events
-    tools.log.debug(`Getting activity for ${GH_USERNAME}`);
+    tools.log.debug(`Getting activity for ${GH_USERNAME} pls`);
     const events = await tools.github.activity.listPublicEventsForUser({
       username: GH_USERNAME,
       per_page: 100,

--- a/index.js
+++ b/index.js
@@ -190,6 +190,7 @@ const serializers = {
 
 Toolkit.run(
   async (tools) => {
+	tools.log.debug("Filters:" + FILTER_EVENTS)
     // Get the user's public events
     tools.log.debug(`Getting activity for ${GH_USERNAME}`);
     const events = await tools.github.activity.listPublicEventsForUser({

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ Toolkit.run(
       per_page: 100,
     });
     tools.log.debug(
-      `Activity for ${GH_USERNAME}, ${events.data.length} events found.`,
+      `Activity for ${GH_USERNAME}, ${events.data.length} events found YES.`,
     );
 
     const content = events.data

--- a/index.js
+++ b/index.js
@@ -190,16 +190,14 @@ const serializers = {
 
 Toolkit.run(
   async (tools) => {
-	console.log("Print")
-	tools.log.debug("Filters:" + FILTER_EVENTS)
     // Get the user's public events
-    tools.log.debug(`Getting activity for ${GH_USERNAME} pls`);
+    tools.log.debug(`Getting activity for ${GH_USERNAME}`);
     const events = await tools.github.activity.listPublicEventsForUser({
       username: GH_USERNAME,
       per_page: 100,
     });
     tools.log.debug(
-      `Activity for ${GH_USERNAME}, ${events.data.length} events found YES.`,
+      `Activity for ${GH_USERNAME}, ${events.data.length} events found.`,
     );
 
     const content = events.data

--- a/index.js
+++ b/index.js
@@ -207,6 +207,8 @@ Toolkit.run(
       .slice(0, MAX_LINES)
       // Call the serializer to construct a string
       .map((item) => serializers[item.type](item));
+	
+	tools.log.debug(content)
 
     const readmeContent = fs
       .readFileSync(`./${TARGET_FILE}`, "utf-8")

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const COMMIT_MSG = core.getInput("COMMIT_MSG");
 const MAX_LINES = core.getInput("MAX_LINES");
 const TARGET_FILE = core.getInput("TARGET_FILE");
 const EMPTY_COMMIT_MSG = core.getInput("EMPTY_COMMIT_MSG");
+const FILTER_EVENTS = core.getInput("FILTER_EVENTS");
 
 /**
  * Returns the sentence case representation
@@ -201,7 +202,7 @@ Toolkit.run(
 
     const content = events.data
       // Filter out any boring activity
-      .filter((event) => serializers.hasOwnProperty(event.type))
+      .filter((event) => serializers.hasOwnProperty(event.type) && FILTER_EVENTS.includes(event.type))
       // We only have five lines to work with
       .slice(0, MAX_LINES)
       // Call the serializer to construct a string

--- a/index.js
+++ b/index.js
@@ -207,8 +207,6 @@ Toolkit.run(
       .slice(0, MAX_LINES)
       // Call the serializer to construct a string
       .map((item) => serializers[item.type](item));
-	
-	tools.log.debug(content)
 
     const readmeContent = fs
       .readFileSync(`./${TARGET_FILE}`, "utf-8")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-activity-readme",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-activity-readme",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "Updates README with the recent GitHub activity of a user",
   "main": "index.js",
   "keywords": [],


### PR DESCRIPTION
Added a workflow option to specify which events types to display on the profile. I took the simplest approach. Let me know if there is anything to change. 

`actions.yml` has a new variable which is a simple string containing all valid Event types.
```yaml
  FILTER_EVENTS:
    description: "Events that should be displayed on profile"
    default: "IssueCommentEvent, IssuesEvent, PullRequestEvent, ReleaseEvent"
    required: false
```

A user can specify the event type by doing the following in their yaml:

```yaml
    steps:
      - uses: actions/checkout@v4
      - uses: jamesgeorge007/github-activity-readme@master
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          FILTER_EVENTS: "{Events to display}"
```

Closes issue #82 